### PR TITLE
Update the OpenAI URL to point to chatgpt.com.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
           "https://www.phind.com/*",
           "https://claude.ai/*",
           "https://gemini.google.com/*",
-          "https://chat.openai.com/*"
+          "https://chatgpt.com/*"
         ]
       }
     ]


### PR DESCRIPTION
Update the OpenAI URL to point to chatgpt.com.
