### PR TITLE
Add Ctrl+Enter to send prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+- 0.38.0 (2025/02/01)
+
+  - Feature: Pressing Ctrl+Enter in the textarea now triggers the send button action based on the interface language.
+  - Added an event listener for the Ctrl+Enter key combination in `scripts/content.js`.
+  - The event listener is registered on `document.body` and checks if the target is a textarea.
+
 - 0.37.0 (2025/01/19)
 
   - Fix a bug on initial buttons detection.

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -1,9 +1,9 @@
 # Pubilsh Notes
 
-1. Simply zip whole folder as a zip file such as `ChatGPTToolkitExtension_v0.37.0.zip`
+1. Simply zip whole folder as a zip file such as `ChatGPTToolkitExtension_v0.38.0.zip`
 
     ```sh
-    7z a ChatGPTToolkitExtension_v0.37.0.zip _locales images scripts CHANGELOG.md manifest.json README.md
+    7z a ChatGPTToolkitExtension_v0.38.0.zip _locales images scripts CHANGELOG.md manifest.json README.md
     ```
 
 2. Publish to Chrome Web Store.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "__MSG_chatgpttoolkit_name__",
     "description": "__MSG_chatgpttoolkit_description__",
-    "version": "0.37.0",
+    "version": "0.38.0",
     "default_locale": "zh_TW",
     "author": "__MSG_chatgpttoolkit_author__",
     "icons": {

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -805,4 +805,18 @@
         }
     });
 
+    // Add an event listener for the Ctrl+Enter key combination on document.body
+    document.body.addEventListener('keyup', (event) => {
+        if (event.ctrlKey && event.key === 'Enter') {
+            // Check if the target element is a textarea
+            if (event.target.tagName === 'TEXTAREA') {
+                // Locate the send button based on the relative position of the button related to the textarea
+                const sendButton = event.target.closest('div.group\\/conversation-turn').querySelector('button.btn-primary');
+                if (sendButton) {
+                    sendButton.click();
+                }
+            }
+        }
+    });
+
 })();


### PR DESCRIPTION
Fixes #13

Add feature to trigger send button with Ctrl+Enter in textarea.

* Add event listener for Ctrl+Enter key combination on `document.body` in `scripts/content.js`
* Check if the target element is a `textarea`
* Locate the send button based on the relative position of the button related to the textarea
* Click the send button if found, otherwise ignore the error
* Update version to `0.38.0` in `manifest.json`
* Add new entry for version `0.38.0` in `CHANGELOG.md` with feature description
* Update publish notes in `PUBLISH.md` to reflect new version `0.38.0`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/doggy8088/ChatGPTToolkitExtension/pull/15?shareId=59f7c401-182c-42b8-8992-440238fe49d0).