### PR TITLE
Add unit tests for i18n getMessage

### DIFF
--- a/tests/PromptsStorageService.test.ts
+++ b/tests/PromptsStorageService.test.ts
@@ -154,21 +154,21 @@ describe('PromptsStorageService', () => {
     test('should throw error for non-array JSON', () => {
       const jsonString = '{"not": "an array"}';
 
-      expect(() => PromptsStorageService.importPrompts(jsonString)).toThrow('必須是陣列格式');
+      expect(() => PromptsStorageService.importPrompts(jsonString)).toThrow('options_import_error_not_array');
     });
 
     test('should throw error for prompts without title', () => {
       const invalidPrompts = [{ prompt: 'Test' }];
       const jsonString = JSON.stringify(invalidPrompts);
 
-      expect(() => PromptsStorageService.importPrompts(jsonString)).toThrow('必須包含 title 和 prompt');
+      expect(() => PromptsStorageService.importPrompts(jsonString)).toThrow('options_import_error_missing_fields');
     });
 
     test('should throw error for prompts without prompt field', () => {
       const invalidPrompts = [{ title: 'Test' }];
       const jsonString = JSON.stringify(invalidPrompts);
 
-      expect(() => PromptsStorageService.importPrompts(jsonString)).toThrow('必須包含 title 和 prompt');
+      expect(() => PromptsStorageService.importPrompts(jsonString)).toThrow('options_import_error_missing_fields');
     });
 
     test('should accept prompts with optional fields', () => {

--- a/tests/i18n.test.ts
+++ b/tests/i18n.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { getMessage } from '../src/options/utils/i18n';
+
+describe('i18n', () => {
+  const originalChrome = globalThis.chrome;
+
+  beforeEach(() => {
+    // Reset chrome global before each test
+    // We don't restore here because we modify it in tests
+    // But we should start clean
+    (globalThis as any).chrome = undefined;
+  });
+
+  afterEach(() => {
+    // Restore original chrome global after each test
+    (globalThis as any).chrome = originalChrome;
+  });
+
+  describe('getMessage', () => {
+    test('should return key when chrome is undefined', () => {
+      (globalThis as any).chrome = undefined;
+      expect(getMessage('testKey')).toBe('testKey');
+    });
+
+    test('should return key when chrome.i18n is undefined', () => {
+      (globalThis as any).chrome = {};
+      expect(getMessage('testKey')).toBe('testKey');
+    });
+
+    test('should return key when chrome.i18n.getMessage is undefined', () => {
+      (globalThis as any).chrome = { i18n: {} };
+      expect(getMessage('testKey')).toBe('testKey');
+    });
+
+    test('should return message from chrome.i18n.getMessage', () => {
+      const getMessageMock = mock((key: string) => `Translated ${key}`);
+      (globalThis as any).chrome = {
+        i18n: {
+          getMessage: getMessageMock
+        }
+      };
+
+      expect(getMessage('hello')).toBe('Translated hello');
+      expect(getMessageMock).toHaveBeenCalledWith('hello', undefined);
+    });
+
+    test('should return key when chrome.i18n.getMessage returns empty string', () => {
+      const getMessageMock = mock(() => '');
+      (globalThis as any).chrome = {
+        i18n: {
+          getMessage: getMessageMock
+        }
+      };
+
+      expect(getMessage('hello')).toBe('hello');
+    });
+
+    test('should return key when chrome.i18n.getMessage returns null/undefined', () => {
+      const getMessageMock = mock(() => null);
+      (globalThis as any).chrome = {
+        i18n: {
+          getMessage: getMessageMock
+        }
+      };
+
+      expect(getMessage('hello')).toBe('hello');
+    });
+
+    test('should pass substitutions to chrome.i18n.getMessage', () => {
+      const getMessageMock = mock((key: string, subs: string[]) => `${key} ${subs.join(' ')}`);
+      (globalThis as any).chrome = {
+        i18n: {
+          getMessage: getMessageMock
+        }
+      };
+
+      expect(getMessage('hello', ['world'])).toBe('hello world');
+      expect(getMessageMock).toHaveBeenCalledWith('hello', ['world']);
+    });
+  });
+});


### PR DESCRIPTION
- Added unit tests for `getMessage` function in `src/options/utils/i18n.ts`.
- Fixed existing test failures in `tests/PromptsStorageService.test.ts` by updating expectations to match fallback behavior (returning i18n keys) when `chrome.i18n` is not available.
- Coverage:
  - `getMessage`:
    - `chrome` undefined
    - `chrome.i18n` undefined
    - `getMessage` undefined
    - `getMessage` returns string
    - `getMessage` returns empty/null
    - Substitutions
- Result: Increased test coverage and fixed regression in existing tests.

---
*PR created automatically by Jules for task [15490105076312407861](https://jules.google.com/task/15490105076312407861) started by @doggy8088*