### PR TITLE
🧪 Add unit tests for getUriComponent

### DIFF
--- a/tests/content-utils.test.js
+++ b/tests/content-utils.test.js
@@ -12,7 +12,31 @@ if (!contentUtils || typeof contentUtils.parseToolkitHash !== "function") {
   throw new Error("Missing ChatGPTToolkitContentUtils exports from scripts/content-utils.js");
 }
 
-const { parseToolkitHash, flexiblePromptDetection, b64EncodeUnicode } = contentUtils;
+const { parseToolkitHash, flexiblePromptDetection, b64EncodeUnicode, getUriComponent } = contentUtils;
+
+test("getUriComponent: extracts value when key matches", () => {
+  assert.equal(getUriComponent("foo=bar", "foo"), "bar");
+});
+
+test("getUriComponent: returns undefined when key does not match", () => {
+  assert.equal(getUriComponent("foo=bar", "baz"), undefined);
+});
+
+test("getUriComponent: returns undefined when no equals sign is present", () => {
+  assert.equal(getUriComponent("foobar", "foo"), undefined);
+});
+
+test("getUriComponent: returns undefined when key is empty", () => {
+  assert.equal(getUriComponent("=bar", ""), undefined);
+});
+
+test("getUriComponent: returns undefined when value is empty", () => {
+  assert.equal(getUriComponent("foo=", "foo"), undefined);
+});
+
+test("getUriComponent: handles multiple equals signs (first one is delimiter)", () => {
+  assert.equal(getUriComponent("foo=bar=baz", "foo"), "bar=baz");
+});
 
 test("parseToolkitHash: phind-style encoding decodes to expected prompt", () => {
   const hash = "autoSubmit=false&prompt=I%2BB+%3D+C%26D";


### PR DESCRIPTION
This PR adds unit tests for the `getUriComponent` function in `scripts/content-utils.js`.

🎯 **What:** The testing gap for `getUriComponent`, a pure function used for parsing URI components, has been addressed.
📊 **Coverage:** The new tests cover:
- Successful value extraction for a matching key.
- Correct handling of key mismatches (returns `undefined`).
- Handling of malformed input (missing `=`).
- Edge cases like empty keys or values.
- Proper handling of multiple `=` characters (first one as delimiter).
✨ **Result:** Increased test coverage and reliability for core utility functions in the content script helpers.

---
*PR created automatically by Jules for task [1098005243582461472](https://jules.google.com/task/1098005243582461472) started by @doggy8088*