### PR TITLE
修改文字插入的方式

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+- 0.45.1 (2026/06/25)
+
+  - Chore
+    - 將擴充套件版本由 `0.45.0` 升級為 `0.45.1`。
+    - 同步更新 `options.html` 頁尾顯示版本為 `0.45.1`。
+
+  - New features
+    - None
+
+  - Bug fixes
+    - 修正前綴插入判斷誤將部分字首視為已存在的問題，避免像 `hello` 與 `he` 這類情況被誤判而跳過插入。
+    - 改善 contenteditable 文字讀取邏輯：元素已連接 DOM 時優先使用 `innerText`，降低 `<br>` 與巢狀區塊造成換行錯誤的機率。
+    - 抽出共用 `normalizeComparableText`，統一 ChatGPT 與 Gemini 的文字正規化邏輯，減少重複程式碼。
+
+  - Breaking changes
+    - None
+
 - 0.45.0 (2026/06/25)
 
   - Chore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+- 0.45.0 (2026/06/25)
+
+  - Chore
+    - 將擴充套件版本由 `0.44.4` 升級為 `0.45.0`。
+    - 同步更新 `options.html` 頁尾顯示版本為 `0.45.0`。
+
+  - New features
+    - 新增跨站點「前綴插入」提示文字行為：填入 prompt 時保留原輸入內容，並將新文字插在前方。
+    - 新增共用 prompt 組裝邏輯，統一支援 `{{args}}` 佔位符替換與剪貼簿內容拼接規則。
+
+  - Bug fixes
+    - 改善 ChatGPT 輸入編輯器偵測與寫入相容性，支援 `textarea` 與 `contenteditable` 路徑，降低版面變動造成填入失敗的機率。
+    - 修正多站點（Claude、Gemini、Groq、Perplexity、Phind）原本可能覆蓋使用者既有輸入內容的問題。
+
+  - Breaking changes
+    - None
+
 - 0.44.4 (2026/06/20)
 
   - Chore

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "__MSG_chatgpttoolkit_name__",
     "description": "__MSG_chatgpttoolkit_description__",
-    "version": "0.45.0",
+    "version": "0.45.1",
     "default_locale": "zh_TW",
     "author": "__MSG_chatgpttoolkit_author__",
     "background": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "__MSG_chatgpttoolkit_name__",
     "description": "__MSG_chatgpttoolkit_description__",
-    "version": "0.44.4",
+    "version": "0.45.0",
     "default_locale": "zh_TW",
     "author": "__MSG_chatgpttoolkit_author__",
     "background": {

--- a/options.html
+++ b/options.html
@@ -633,7 +633,7 @@
 	        </div>
 
             <footer class="page-footer">
-                <span data-i18n="options_footer_version_label"></span><span id="appVersion">0.44.4</span>
+                <span data-i18n="options_footer_version_label"></span><span id="appVersion">0.45.0</span>
             </footer>
 	    </div>
 

--- a/options.html
+++ b/options.html
@@ -633,7 +633,7 @@
 	        </div>
 
             <footer class="page-footer">
-                <span data-i18n="options_footer_version_label"></span><span id="appVersion">0.45.0</span>
+                <span data-i18n="options_footer_version_label"></span><span id="appVersion">0.45.1</span>
             </footer>
 	    </div>
 

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -25,7 +25,10 @@ ${existingText}`;
       return true;
     const normalizedExisting = normalizeComparableText(existingText);
     const normalizedPrefix = normalizeComparableText(prefixText);
-    return normalizedPrefix.length > 0 && normalizedExisting.startsWith(normalizedPrefix);
+    if (normalizedPrefix.length > 0 && normalizedExisting.startsWith(normalizedPrefix)) {
+      return normalizedExisting.length === normalizedPrefix.length || normalizedExisting.charAt(normalizedPrefix.length) === " ";
+    }
+    return false;
   }
   function resolvePromptText(promptText, clipboardText, placeholder = CLIPBOARD_ARGS_PLACEHOLDER) {
     const trimmedClipboard = clipboardText.trim();
@@ -53,6 +56,9 @@ ${existingText}`;
     function readTargetText(target) {
       if (target instanceof HTMLTextAreaElement) {
         return target.value;
+      }
+      if (target.isConnected) {
+        return target.innerText;
       }
       return Array.from(target.childNodes).map((node) => {
         if (node.nodeType === Node.TEXT_NODE) {
@@ -340,11 +346,10 @@ ${existingText}`;
       });
     }
     function normalizeEditorText(text) {
-      return (text || "").replace(/[\u200B-\u200D\uFEFF]/g, "").replace(/\u00A0/g, " ").replace(/\s+/g, " ").trim();
+      return normalizeComparableText(text);
     }
     function fillPrompt(prompt, autoSubmit = true) {
       const runId = ++promptFillRunId;
-      const expected = normalizeEditorText(prompt);
       let autoSubmitScheduled = false;
       ctx.startRetryInterval({
         intervalMs: 80,
@@ -355,8 +360,9 @@ ${existingText}`;
           const editorDiv = getPromptEditor();
           if (!editorDiv)
             return false;
-          const current = normalizeEditorText(editorDiv.innerText || editorDiv.textContent || "");
-          const hasPrompt = expected.length > 0 ? current.includes(expected) : current.length > 0;
+          const rawCurrent = editorDiv.innerText || editorDiv.textContent || "";
+          const current = normalizeEditorText(rawCurrent);
+          const hasPrompt = prompt.length > 0 ? hasPrefixText(rawCurrent, prompt) : current.length > 0;
           if (hasPrompt) {
             if (autoSubmit && !autoSubmitScheduled) {
               autoSubmitScheduled = true;
@@ -1992,7 +1998,7 @@ ${existingText}`;
       });
     }
     function normalizeEditorText(text) {
-      return (text || "").replace(/[\u200B-\u200D\uFEFF]/g, "").replace(/\u00A0/g, " ").replace(/\s+/g, " ").trim();
+      return normalizeComparableText(text);
     }
     let promptFillRunId = 0;
     function fillPrompt(prompt, autoSubmit = true) {
@@ -2019,8 +2025,9 @@ ${existingText}`;
           }
           if (!div)
             return false;
-          const current = normalizeEditorText(div instanceof HTMLTextAreaElement ? div.value : div.innerText || div.textContent || "");
-          const hasPrompt = expected.length > 0 ? current.includes(expected) : current.length > 0;
+          const rawCurrent = div instanceof HTMLTextAreaElement ? div.value : div.innerText || div.textContent || "";
+          const current = normalizeEditorText(rawCurrent);
+          const hasPrompt = prompt.length > 0 ? hasPrefixText(rawCurrent, prompt) : current.length > 0;
           if (debug) {
             console.log("[ChatGPTToolkit][chatgpt] fillPrompt tick", {
               runId,
@@ -2200,4 +2207,4 @@ ${existingText}`;
   runContentScript();
 })();
 
-//# debugId=7961037783291CCC64756E2164756E21
+//# debugId=7EC7CE1B8385DCF364756E2164756E21

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,5 +1,41 @@
 (() => {
   // src/content/context.ts
+  var CLIPBOARD_ARGS_PLACEHOLDER = "{{args}}";
+  function buildPrefixedText(newText, existingText) {
+    if (!existingText)
+      return newText;
+    if (!newText)
+      return existingText;
+    return newText.endsWith(`
+`) ? `${newText}${existingText}` : `${newText}
+${existingText}`;
+  }
+  function normalizeComparableText(text) {
+    return (text || "").replace(/[\u200B-\u200D\uFEFF]/g, "").replace(/\u00A0/g, " ").replace(/\s+/g, " ").trim();
+  }
+  function hasPrefixText(existingText, prefixText) {
+    if (!existingText || !prefixText)
+      return false;
+    if (existingText === prefixText)
+      return true;
+    const rawPrefixWithBreak = prefixText.endsWith(`
+`) ? prefixText : `${prefixText}
+`;
+    if (existingText.startsWith(rawPrefixWithBreak))
+      return true;
+    const normalizedExisting = normalizeComparableText(existingText);
+    const normalizedPrefix = normalizeComparableText(prefixText);
+    return normalizedPrefix.length > 0 && normalizedExisting.startsWith(normalizedPrefix);
+  }
+  function resolvePromptText(promptText, clipboardText, placeholder = CLIPBOARD_ARGS_PLACEHOLDER) {
+    const trimmedClipboard = clipboardText.trim();
+    if (!trimmedClipboard)
+      return promptText;
+    if (promptText.includes(placeholder)) {
+      return promptText.split(placeholder).join(trimmedClipboard);
+    }
+    return buildPrefixedText(promptText, trimmedClipboard);
+  }
   function createContentContext() {
     const debug = true;
     const contentUtils = window.ChatGPTToolkitContentUtils;
@@ -14,10 +50,28 @@
       tool: "",
       pastingImage: false
     };
-    function fillContentEditableWithParagraphs(target, text) {
+    function readTargetText(target) {
+      if (target instanceof HTMLTextAreaElement) {
+        return target.value;
+      }
+      return Array.from(target.childNodes).map((node) => {
+        if (node.nodeType === Node.TEXT_NODE) {
+          return node.textContent || "";
+        }
+        if (node instanceof HTMLBRElement) {
+          return `
+`;
+        }
+        return node.textContent || "";
+      }).join(`
+`);
+    }
+    function fillContentEditableWithParagraphs(target, text, preserveExistingText = false) {
       if (!target)
         return;
-      const lines = (text || "").split(`
+      const existingText = readTargetText(target);
+      const nextText = preserveExistingText ? hasPrefixText(existingText, text) ? existingText : buildPrefixedText(text, existingText) : text;
+      const lines = (nextText || "").split(`
 `);
       target.innerHTML = "";
       lines.forEach((line) => {
@@ -26,10 +80,11 @@
         target.appendChild(paragraph);
       });
     }
-    function fillTextareaAndDispatchInput(textarea, text) {
+    function fillTextareaAndDispatchInput(textarea, text, preserveExistingText = false) {
       if (!textarea)
         return;
-      textarea.value = text;
+      const existingText = readTargetText(textarea);
+      textarea.value = preserveExistingText ? hasPrefixText(existingText, text) ? existingText : buildPrefixedText(text, existingText) : text;
       textarea.dispatchEvent(new Event("input", { bubbles: true }));
     }
     function startRetryInterval({ intervalMs = 500, retries = 10, tick }) {
@@ -146,7 +201,7 @@
         const textarea = document.querySelector("div[contenteditable]");
         if (!textarea)
           return false;
-        ctx.fillContentEditableWithParagraphs(textarea, params.prompt);
+        ctx.fillContentEditableWithParagraphs(textarea, params.prompt, true);
         const button = document.querySelector("button");
         if (!button)
           return false;
@@ -168,7 +223,6 @@
       return false;
     const { state, debug } = ctx;
     const CUSTOM_PROMPTS_KEY = "chatgpttoolkit.customPrompts";
-    const CLIPBOARD_ARGS_PLACEHOLDER = "{{args}}";
     const GEMINI_EDITOR_SELECTORS = [
       "chat-window .textarea",
       "input-container rich-textarea .ql-editor",
@@ -190,11 +244,10 @@
       }
       return null;
     }
-    function setGeminiPromptEditor(editorDiv, promptText) {
+    function setGeminiPromptEditor(editorDiv, promptText, preserveExistingText = false) {
       if (!editorDiv)
         return;
-      ctx.fillContentEditableWithParagraphs(editorDiv, promptText);
-      editorDiv.dispatchEvent(new Event("input", { bubbles: true }));
+      ctx.fillContentEditableWithParagraphs(editorDiv, promptText, preserveExistingText);
       editorDiv.focus();
     }
     function readClipboardTextSafely() {
@@ -255,7 +308,7 @@
       });
     }
     function normalizeEditorText(text) {
-      return text.replace(/\s+/g, " ").trim();
+      return (text || "").replace(/[\u200B-\u200D\uFEFF]/g, "").replace(/\u00A0/g, " ").replace(/\s+/g, " ").trim();
     }
     function fillPrompt(prompt, autoSubmit = true) {
       const runId = ++promptFillRunId;
@@ -279,7 +332,7 @@
             }
             return true;
           }
-          setGeminiPromptEditor(editorDiv, prompt);
+          setGeminiPromptEditor(editorDiv, prompt, true);
           if (autoSubmit && !autoSubmitScheduled) {
             autoSubmitScheduled = true;
             autoSubmitWhenReady();
@@ -314,15 +367,11 @@
         }
         if (autoPasteEnabled) {
           readClipboardTextSafely().then((text) => {
-            const trimmed = text.trim();
-            const hasArgsPlaceholder = item.prompt.includes(CLIPBOARD_ARGS_PLACEHOLDER);
-            const nextPrompt = hasArgsPlaceholder ? item.prompt.split(CLIPBOARD_ARGS_PLACEHOLDER).join(trimmed) : trimmed ? item.prompt + trimmed : item.prompt;
+            const nextPrompt = resolvePromptText(item.prompt, text);
             if (debug) {
               console.log(`[ChatGPTToolkit][gemini] ${label} button clipboard resolved`, {
                 title: item.title,
                 clipboardLength: text.length,
-                trimmedLength: trimmed.length,
-                hasArgsPlaceholder,
                 nextPromptLength: nextPrompt.length
               });
             }
@@ -789,7 +838,7 @@
         tryClickImageToolButton();
         const textarea = getPromptEditor();
         if (textarea && state.prompt && !promptFilled) {
-          setGeminiPromptEditor(textarea, state.prompt);
+          setGeminiPromptEditor(textarea, state.prompt, true);
           promptFilled = true;
         }
         if (textarea && state.pasteImage && !pastingGeminiImage && !geminiImagePasteAttempted) {
@@ -837,7 +886,7 @@
         const textarea = document.getElementById("chat");
         if (!textarea)
           return false;
-        ctx.fillTextareaAndDispatchInput(textarea, params.prompt);
+        ctx.fillTextareaAndDispatchInput(textarea, params.prompt, true);
         if (params.autoSubmit) {
           setTimeout(() => {
             const btn = textarea.parentElement?.querySelector("button");
@@ -864,7 +913,7 @@
         const textarea = document.querySelector("textarea[autofocus]");
         if (!textarea)
           return false;
-        ctx.fillTextareaAndDispatchInput(textarea, params.prompt);
+        ctx.fillTextareaAndDispatchInput(textarea, params.prompt, true);
         if (params.autoSubmit) {
           setTimeout(() => {
             const buttons = textarea.parentElement?.querySelectorAll("button");
@@ -892,7 +941,7 @@
         const textarea = document.querySelector('textarea[name="q"]');
         if (!textarea)
           return false;
-        ctx.fillTextareaAndDispatchInput(textarea, params.prompt);
+        ctx.fillTextareaAndDispatchInput(textarea, params.prompt, true);
         if (params.autoSubmit) {
           textarea.form?.submit();
         }
@@ -905,12 +954,10 @@
   // src/content/sites/chatgpt.ts
   function initChatGPT(ctx) {
     const { state, debug } = ctx;
-    const CLIPBOARD_ARGS_PLACEHOLDER = "{{args}}";
-    function setChatGPTPromptEditor(editorDiv, promptText) {
+    function setChatGPTPromptEditor(editorDiv, promptText, preserveExistingText = false) {
       if (!editorDiv)
         return;
-      editorDiv.innerHTML = "<p>" + promptText + "</p>";
-      editorDiv.dispatchEvent(new Event("input", { bubbles: true }));
+      ctx.fillContentEditableWithParagraphs(editorDiv, promptText, preserveExistingText);
       editorDiv.focus();
     }
     function readClipboardTextSafely() {
@@ -948,15 +995,11 @@
         }
         if (autoPasteEnabled) {
           readClipboardTextSafely().then((text) => {
-            const trimmed = text.trim();
-            const hasArgsPlaceholder = item.prompt.includes(CLIPBOARD_ARGS_PLACEHOLDER);
-            const nextPrompt = hasArgsPlaceholder ? item.prompt.split(CLIPBOARD_ARGS_PLACEHOLDER).join(trimmed) : trimmed ? item.prompt + trimmed : item.prompt;
+            const nextPrompt = resolvePromptText(item.prompt, text);
             if (debug) {
               console.log(`[ChatGPTToolkit][chatgpt] ${label} button clipboard resolved`, {
                 title: item.title,
                 clipboardLength: text.length,
-                trimmedLength: trimmed.length,
-                hasArgsPlaceholder,
                 nextPromptLength: nextPrompt.length
               });
             }
@@ -1149,7 +1192,7 @@
       }
       if (state.prompt) {
         logEditorState(textarea, "before prompt fill");
-        setChatGPTPromptEditor(textarea, state.prompt);
+        setChatGPTPromptEditor(textarea, state.prompt, true);
         logEditorState(textarea, "after prompt fill");
       }
       history.replaceState({}, document.title, window.location.pathname + window.location.search);
@@ -1598,7 +1641,7 @@
       });
     }
     function normalizeEditorText(text) {
-      return text.replace(/\s+/g, " ").trim();
+      return (text || "").replace(/[\u200B-\u200D\uFEFF]/g, "").replace(/\u00A0/g, " ").replace(/\s+/g, " ").trim();
     }
     let promptFillRunId = 0;
     function fillPrompt(prompt, autoSubmit = true) {
@@ -1644,7 +1687,7 @@
             }
             return true;
           }
-          setChatGPTPromptEditor(div, prompt);
+          setChatGPTPromptEditor(div, prompt, true);
           placeCaretAtEnd(div);
           if (debug) {
             console.log("[ChatGPTToolkit][chatgpt] fillPrompt wrote prompt", {
@@ -1806,4 +1849,4 @@
   runContentScript();
 })();
 
-//# debugId=6509FA7E849958BA64756E2164756E21
+//# debugId=08A836CB97727EC664756E2164756E21

--- a/src/content/context.ts
+++ b/src/content/context.ts
@@ -17,6 +17,49 @@ interface ContentUtilsApi {
   parseToolkitHash: (hash: string, locationSearch: string) => ParsedToolkitHash;
 }
 
+export const CLIPBOARD_ARGS_PLACEHOLDER = '{{args}}';
+
+export function buildPrefixedText(newText: string, existingText: string) {
+  if (!existingText) return newText;
+  if (!newText) return existingText;
+  return newText.endsWith('\n') ? `${newText}${existingText}` : `${newText}\n${existingText}`;
+}
+
+function normalizeComparableText(text: string) {
+  return (text || '')
+    .replace(/[\u200B-\u200D\uFEFF]/g, '')
+    .replace(/\u00A0/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function hasPrefixText(existingText: string, prefixText: string) {
+  if (!existingText || !prefixText) return false;
+  if (existingText === prefixText) return true;
+
+  const rawPrefixWithBreak = prefixText.endsWith('\n') ? prefixText : `${prefixText}\n`;
+  if (existingText.startsWith(rawPrefixWithBreak)) return true;
+
+  const normalizedExisting = normalizeComparableText(existingText);
+  const normalizedPrefix = normalizeComparableText(prefixText);
+  return normalizedPrefix.length > 0 && normalizedExisting.startsWith(normalizedPrefix);
+}
+
+export function resolvePromptText(
+  promptText: string,
+  clipboardText: string,
+  placeholder = CLIPBOARD_ARGS_PLACEHOLDER
+) {
+  const trimmedClipboard = clipboardText.trim();
+  if (!trimmedClipboard) return promptText;
+
+  if (promptText.includes(placeholder)) {
+    return promptText.split(placeholder).join(trimmedClipboard);
+  }
+
+  return buildPrefixedText(promptText, trimmedClipboard);
+}
+
 export interface ParamsState {
   prompt: string;
   autoSubmit: boolean;
@@ -30,8 +73,16 @@ export interface ContentContext {
   state: ParamsState;
   refreshParamsFromHash: () => ParamsState | null;
   clearHash: () => void;
-  fillContentEditableWithParagraphs: (target: HTMLElement | null, text: string) => void;
-  fillTextareaAndDispatchInput: (textarea: HTMLTextAreaElement | null, text: string) => void;
+  fillContentEditableWithParagraphs: (
+    target: HTMLElement | null,
+    text: string,
+    preserveExistingText?: boolean
+  ) => void;
+  fillTextareaAndDispatchInput: (
+    textarea: HTMLTextAreaElement | null,
+    text: string,
+    preserveExistingText?: boolean
+  ) => void;
   startRetryInterval: (options: RetryIntervalOptions) => number;
   delay: (ms: number) => Promise<void>;
   fetchClipboardImageAndSimulatePaste: (targetElement: HTMLElement | null) => Promise<boolean>;
@@ -55,9 +106,39 @@ export function createContentContext(): ContentContext | null {
     pastingImage: false,
   };
 
-  function fillContentEditableWithParagraphs(target: HTMLElement | null, text: string) {
+  function readTargetText(target: HTMLElement | HTMLTextAreaElement) {
+    if (target instanceof HTMLTextAreaElement) {
+      return target.value;
+    }
+
+    return Array.from(target.childNodes)
+      .map((node) => {
+        if (node.nodeType === Node.TEXT_NODE) {
+          return node.textContent || '';
+        }
+
+        if (node instanceof HTMLBRElement) {
+          return '\n';
+        }
+
+        return (node as HTMLElement).textContent || '';
+      })
+      .join('\n');
+  }
+
+  function fillContentEditableWithParagraphs(
+    target: HTMLElement | null,
+    text: string,
+    preserveExistingText = false
+  ) {
     if (!target) return;
-    const lines = (text || '').split('\n');
+    const existingText = readTargetText(target);
+    const nextText = preserveExistingText
+      ? hasPrefixText(existingText, text)
+        ? existingText
+        : buildPrefixedText(text, existingText)
+      : text;
+    const lines = (nextText || '').split('\n');
     target.innerHTML = '';
     lines.forEach((line) => {
       const paragraph = document.createElement('p');
@@ -66,9 +147,18 @@ export function createContentContext(): ContentContext | null {
     });
   }
 
-  function fillTextareaAndDispatchInput(textarea: HTMLTextAreaElement | null, text: string) {
+  function fillTextareaAndDispatchInput(
+    textarea: HTMLTextAreaElement | null,
+    text: string,
+    preserveExistingText = false
+  ) {
     if (!textarea) return;
-    textarea.value = text;
+    const existingText = readTargetText(textarea);
+    textarea.value = preserveExistingText
+      ? hasPrefixText(existingText, text)
+        ? existingText
+        : buildPrefixedText(text, existingText)
+      : text;
     textarea.dispatchEvent(new Event('input', { bubbles: true }));
   }
 

--- a/src/content/context.ts
+++ b/src/content/context.ts
@@ -25,7 +25,7 @@ export function buildPrefixedText(newText: string, existingText: string) {
   return newText.endsWith('\n') ? `${newText}${existingText}` : `${newText}\n${existingText}`;
 }
 
-function normalizeComparableText(text: string) {
+export function normalizeComparableText(text: string) {
   return (text || '')
     .replace(/[\u200B-\u200D\uFEFF]/g, '')
     .replace(/\u00A0/g, ' ')
@@ -33,7 +33,7 @@ function normalizeComparableText(text: string) {
     .trim();
 }
 
-function hasPrefixText(existingText: string, prefixText: string) {
+export function hasPrefixText(existingText: string, prefixText: string) {
   if (!existingText || !prefixText) return false;
   if (existingText === prefixText) return true;
 
@@ -42,7 +42,14 @@ function hasPrefixText(existingText: string, prefixText: string) {
 
   const normalizedExisting = normalizeComparableText(existingText);
   const normalizedPrefix = normalizeComparableText(prefixText);
-  return normalizedPrefix.length > 0 && normalizedExisting.startsWith(normalizedPrefix);
+  if (normalizedPrefix.length > 0 && normalizedExisting.startsWith(normalizedPrefix)) {
+    return (
+      normalizedExisting.length === normalizedPrefix.length ||
+      normalizedExisting.charAt(normalizedPrefix.length) === ' '
+    );
+  }
+
+  return false;
 }
 
 export function resolvePromptText(
@@ -109,6 +116,10 @@ export function createContentContext(): ContentContext | null {
   function readTargetText(target: HTMLElement | HTMLTextAreaElement) {
     if (target instanceof HTMLTextAreaElement) {
       return target.value;
+    }
+
+    if (target.isConnected) {
+      return target.innerText;
     }
 
     return Array.from(target.childNodes)

--- a/src/content/sites/chatgpt.ts
+++ b/src/content/sites/chatgpt.ts
@@ -1,4 +1,5 @@
 import type { ContentContext } from '../context';
+import { resolvePromptText } from '../context';
 
 interface PromptItem {
   enabled?: boolean;
@@ -23,12 +24,14 @@ type MarkmapInstanceHandle = {
 
 export function initChatGPT(ctx: ContentContext) {
   const { state, debug } = ctx;
-  const CLIPBOARD_ARGS_PLACEHOLDER = '{{args}}';
 
-  function setChatGPTPromptEditor(editorDiv: HTMLElement | null, promptText: string) {
+  function setChatGPTPromptEditor(
+    editorDiv: HTMLElement | null,
+    promptText: string,
+    preserveExistingText = false
+  ) {
     if (!editorDiv) return;
-    editorDiv.innerHTML = '<p>' + promptText + '</p>';
-    editorDiv.dispatchEvent(new Event('input', { bubbles: true }));
+    ctx.fillContentEditableWithParagraphs(editorDiv, promptText, preserveExistingText);
     editorDiv.focus();
   }
 
@@ -75,19 +78,11 @@ export function initChatGPT(ctx: ContentContext) {
 
       if (autoPasteEnabled) {
         readClipboardTextSafely().then((text) => {
-          const trimmed = text.trim();
-          const hasArgsPlaceholder = item.prompt.includes(CLIPBOARD_ARGS_PLACEHOLDER);
-          const nextPrompt = hasArgsPlaceholder
-            ? item.prompt.split(CLIPBOARD_ARGS_PLACEHOLDER).join(trimmed)
-            : trimmed
-              ? item.prompt + trimmed
-              : item.prompt;
+          const nextPrompt = resolvePromptText(item.prompt, text);
           if (debug) {
             console.log(`[ChatGPTToolkit][chatgpt] ${label} button clipboard resolved`, {
               title: item.title,
               clipboardLength: text.length,
-              trimmedLength: trimmed.length,
-              hasArgsPlaceholder,
               nextPromptLength: nextPrompt.length,
             });
           }
@@ -286,7 +281,7 @@ export function initChatGPT(ctx: ContentContext) {
 
     if (state.prompt) {
       logEditorState(textarea, 'before prompt fill');
-      setChatGPTPromptEditor(textarea, state.prompt);
+      setChatGPTPromptEditor(textarea, state.prompt, true);
       logEditorState(textarea, 'after prompt fill');
     }
 
@@ -833,7 +828,11 @@ export function initChatGPT(ctx: ContentContext) {
   }
 
   function normalizeEditorText(text: string) {
-    return text.replace(/\s+/g, ' ').trim();
+    return (text || '')
+      .replace(/[\u200B-\u200D\uFEFF]/g, '')
+      .replace(/\u00A0/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
   }
 
   let promptFillRunId = 0;
@@ -884,7 +883,7 @@ export function initChatGPT(ctx: ContentContext) {
           return true;
         }
 
-        setChatGPTPromptEditor(div, prompt);
+        setChatGPTPromptEditor(div, prompt, true);
         placeCaretAtEnd(div);
         if (debug) {
           console.log('[ChatGPTToolkit][chatgpt] fillPrompt wrote prompt', {

--- a/src/content/sites/chatgpt.ts
+++ b/src/content/sites/chatgpt.ts
@@ -1,5 +1,5 @@
 import type { ContentContext } from '../context';
-import { resolvePromptText } from '../context';
+import { hasPrefixText, normalizeComparableText, resolvePromptText } from '../context';
 
 interface PromptItem {
   enabled?: boolean;
@@ -1023,11 +1023,7 @@ export function initChatGPT(ctx: ContentContext) {
   }
 
   function normalizeEditorText(text: string) {
-    return (text || '')
-      .replace(/[\u200B-\u200D\uFEFF]/g, '')
-      .replace(/\u00A0/g, ' ')
-      .replace(/\s+/g, ' ')
-      .trim();
+    return normalizeComparableText(text);
   }
 
   let promptFillRunId = 0;
@@ -1057,10 +1053,10 @@ export function initChatGPT(ctx: ContentContext) {
         }
         if (!div) return false;
 
-        const current = normalizeEditorText(
-          div instanceof HTMLTextAreaElement ? div.value : div.innerText || div.textContent || ''
-        );
-        const hasPrompt = expected.length > 0 ? current.includes(expected) : current.length > 0;
+        const rawCurrent =
+          div instanceof HTMLTextAreaElement ? div.value : div.innerText || div.textContent || '';
+        const current = normalizeEditorText(rawCurrent);
+        const hasPrompt = prompt.length > 0 ? hasPrefixText(rawCurrent, prompt) : current.length > 0;
         if (debug) {
           console.log('[ChatGPTToolkit][chatgpt] fillPrompt tick', {
             runId,

--- a/src/content/sites/claude.ts
+++ b/src/content/sites/claude.ts
@@ -13,7 +13,7 @@ export function initClaude(ctx: ContentContext) {
       const textarea = document.querySelector<HTMLElement>('div[contenteditable]');
       if (!textarea) return false;
 
-      ctx.fillContentEditableWithParagraphs(textarea, params.prompt);
+      ctx.fillContentEditableWithParagraphs(textarea, params.prompt, true);
 
       const button = document.querySelector<HTMLButtonElement>('button');
       if (!button) return false;

--- a/src/content/sites/gemini.ts
+++ b/src/content/sites/gemini.ts
@@ -1,4 +1,5 @@
 import type { ContentContext } from '../context';
+import { resolvePromptText } from '../context';
 
 interface PromptItem {
   enabled?: boolean;
@@ -26,7 +27,6 @@ export function initGemini(ctx: ContentContext) {
 
   const { state, debug } = ctx;
   const CUSTOM_PROMPTS_KEY = 'chatgpttoolkit.customPrompts';
-  const CLIPBOARD_ARGS_PLACEHOLDER = '{{args}}';
   const GEMINI_EDITOR_SELECTORS = [
     'chat-window .textarea',
     'input-container rich-textarea .ql-editor',
@@ -52,10 +52,13 @@ export function initGemini(ctx: ContentContext) {
     return null;
   }
 
-  function setGeminiPromptEditor(editorDiv: HTMLElement | null, promptText: string) {
+  function setGeminiPromptEditor(
+    editorDiv: HTMLElement | null,
+    promptText: string,
+    preserveExistingText = false
+  ) {
     if (!editorDiv) return;
-    ctx.fillContentEditableWithParagraphs(editorDiv, promptText);
-    editorDiv.dispatchEvent(new Event('input', { bubbles: true }));
+    ctx.fillContentEditableWithParagraphs(editorDiv, promptText, preserveExistingText);
     editorDiv.focus();
   }
 
@@ -129,7 +132,11 @@ export function initGemini(ctx: ContentContext) {
   }
 
   function normalizeEditorText(text: string) {
-    return text.replace(/\s+/g, ' ').trim();
+    return (text || '')
+      .replace(/[\u200B-\u200D\uFEFF]/g, '')
+      .replace(/\u00A0/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
   }
 
   function fillPrompt(prompt: string, autoSubmit = true) {
@@ -157,7 +164,7 @@ export function initGemini(ctx: ContentContext) {
           return true;
         }
 
-        setGeminiPromptEditor(editorDiv, prompt);
+        setGeminiPromptEditor(editorDiv, prompt, true);
         if (autoSubmit && !autoSubmitScheduled) {
           autoSubmitScheduled = true;
           autoSubmitWhenReady();
@@ -202,19 +209,11 @@ export function initGemini(ctx: ContentContext) {
 
       if (autoPasteEnabled) {
         readClipboardTextSafely().then((text) => {
-          const trimmed = text.trim();
-          const hasArgsPlaceholder = item.prompt.includes(CLIPBOARD_ARGS_PLACEHOLDER);
-          const nextPrompt = hasArgsPlaceholder
-            ? item.prompt.split(CLIPBOARD_ARGS_PLACEHOLDER).join(trimmed)
-            : trimmed
-              ? item.prompt + trimmed
-              : item.prompt;
+          const nextPrompt = resolvePromptText(item.prompt, text);
           if (debug) {
             console.log(`[ChatGPTToolkit][gemini] ${label} button clipboard resolved`, {
               title: item.title,
               clipboardLength: text.length,
-              trimmedLength: trimmed.length,
-              hasArgsPlaceholder,
               nextPromptLength: nextPrompt.length,
             });
           }
@@ -749,7 +748,7 @@ export function initGemini(ctx: ContentContext) {
 
       const textarea = getPromptEditor();
       if (textarea && state.prompt && !promptFilled) {
-        setGeminiPromptEditor(textarea, state.prompt);
+        setGeminiPromptEditor(textarea, state.prompt, true);
         promptFilled = true;
       }
 

--- a/src/content/sites/gemini.ts
+++ b/src/content/sites/gemini.ts
@@ -1,5 +1,5 @@
 import type { ContentContext } from '../context';
-import { resolvePromptText } from '../context';
+import { hasPrefixText, normalizeComparableText, resolvePromptText } from '../context';
 
 interface PromptItem {
   enabled?: boolean;
@@ -177,16 +177,11 @@ export function initGemini(ctx: ContentContext) {
   }
 
   function normalizeEditorText(text: string) {
-    return (text || '')
-      .replace(/[\u200B-\u200D\uFEFF]/g, '')
-      .replace(/\u00A0/g, ' ')
-      .replace(/\s+/g, ' ')
-      .trim();
+    return normalizeComparableText(text);
   }
 
   function fillPrompt(prompt: string, autoSubmit = true) {
     const runId = ++promptFillRunId;
-    const expected = normalizeEditorText(prompt);
     let autoSubmitScheduled = false;
 
     ctx.startRetryInterval({
@@ -198,8 +193,9 @@ export function initGemini(ctx: ContentContext) {
         const editorDiv = getPromptEditor();
         if (!editorDiv) return false;
 
-        const current = normalizeEditorText(editorDiv.innerText || editorDiv.textContent || '');
-        const hasPrompt = expected.length > 0 ? current.includes(expected) : current.length > 0;
+        const rawCurrent = editorDiv.innerText || editorDiv.textContent || '';
+        const current = normalizeEditorText(rawCurrent);
+        const hasPrompt = prompt.length > 0 ? hasPrefixText(rawCurrent, prompt) : current.length > 0;
 
         if (hasPrompt) {
           if (autoSubmit && !autoSubmitScheduled) {

--- a/src/content/sites/groq.ts
+++ b/src/content/sites/groq.ts
@@ -13,7 +13,7 @@ export function initGroq(ctx: ContentContext) {
       const textarea = document.getElementById('chat') as HTMLTextAreaElement | null;
       if (!textarea) return false;
 
-      ctx.fillTextareaAndDispatchInput(textarea, params.prompt);
+      ctx.fillTextareaAndDispatchInput(textarea, params.prompt, true);
 
       if (params.autoSubmit) {
         setTimeout(() => {

--- a/src/content/sites/perplexity.ts
+++ b/src/content/sites/perplexity.ts
@@ -13,7 +13,7 @@ export function initPerplexity(ctx: ContentContext) {
       const textarea = document.querySelector<HTMLTextAreaElement>('textarea[autofocus]');
       if (!textarea) return false;
 
-      ctx.fillTextareaAndDispatchInput(textarea, params.prompt);
+      ctx.fillTextareaAndDispatchInput(textarea, params.prompt, true);
 
       if (params.autoSubmit) {
         setTimeout(() => {

--- a/src/content/sites/phind.ts
+++ b/src/content/sites/phind.ts
@@ -13,7 +13,7 @@ export function initPhind(ctx: ContentContext) {
       const textarea = document.querySelector<HTMLTextAreaElement>('textarea[name="q"]');
       if (!textarea) return false;
 
-      ctx.fillTextareaAndDispatchInput(textarea, params.prompt);
+      ctx.fillTextareaAndDispatchInput(textarea, params.prompt, true);
 
       if (params.autoSubmit) {
         textarea.form?.submit();

--- a/tests/chatgpt-dom-snapshot.test.ts
+++ b/tests/chatgpt-dom-snapshot.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { initChatGPT } from '../src/content/sites/chatgpt';
-import type { ContentContext } from '../src/content/context';
+import { buildPrefixedText, hasPrefixText, type ContentContext } from '../src/content/context';
 import { ensureHappyDom } from './utils/happyDom';
 
 ensureHappyDom();
@@ -42,7 +42,11 @@ function createContentContext(): ContentContext {
   };
 }
 
-function createPromptUrlContext(): ContentContext {
+function createPromptUrlContext(options?: {
+  prompt?: string;
+  autoSubmit?: boolean;
+  fillTextareaPreservingExistingText?: boolean;
+}): ContentContext {
   const state = {
     prompt: '',
     autoSubmit: false,
@@ -55,17 +59,23 @@ function createPromptUrlContext(): ContentContext {
     debug: false,
     state,
     refreshParamsFromHash: () => {
-      state.prompt = '誰是保哥？';
-      state.autoSubmit = true;
+      state.prompt = options?.prompt || '誰是保哥？';
+      state.autoSubmit = options?.autoSubmit ?? true;
       state.pasteImage = false;
       state.tool = '';
       return state;
     },
     clearHash: () => {},
     fillContentEditableWithParagraphs: () => {},
-    fillTextareaAndDispatchInput: (textarea, text) => {
+    fillTextareaAndDispatchInput: (textarea, text, preserveExistingText = false) => {
       if (!textarea) return;
-      textarea.value = text;
+      const shouldPreserveExistingText =
+        preserveExistingText || options?.fillTextareaPreservingExistingText === true;
+      textarea.value = shouldPreserveExistingText
+        ? hasPrefixText(textarea.value, text)
+          ? textarea.value
+          : buildPrefixedText(text, textarea.value)
+        : text;
       textarea.dispatchEvent(new Event('input', { bubbles: true }));
     },
     startRetryInterval: ({ retries = 10, tick }) => {
@@ -260,6 +270,39 @@ describe('chatgpt.com DOM snapshot', () => {
       const textarea = document.querySelector<HTMLTextAreaElement>('textarea');
       expect(textarea?.value).toBe('誰是保哥？');
       expect(clickCalls).toBe(1);
+    } finally {
+      restoreChrome();
+    }
+  });
+
+  test('fills URL prompt into textarea composer when existing text starts with a partial word match', async () => {
+    document.documentElement.innerHTML = `
+      <head></head>
+      <body>
+        <form>
+          <textarea placeholder="Ask anything">hello</textarea>
+          <button type="button" aria-label="傳送提示詞"></button>
+        </form>
+      </body>
+    `;
+
+    const restoreChrome = installChromeStub();
+
+    try {
+      await withQueuedIntervals(async (flushIntervals) => {
+        initChatGPT(
+          createPromptUrlContext({
+            prompt: 'he',
+            autoSubmit: false,
+            fillTextareaPreservingExistingText: true,
+          })
+        );
+        await flushIntervals();
+        await flushIntervals();
+      });
+
+      const textarea = document.querySelector<HTMLTextAreaElement>('textarea');
+      expect(textarea?.value).toBe('he\nhello');
     } finally {
       restoreChrome();
     }

--- a/tests/content-context.test.ts
+++ b/tests/content-context.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import {
+  buildPrefixedText,
+  createContentContext,
+  resolvePromptText,
+} from '../src/content/context';
+import { ensureHappyDom } from './utils/happyDom';
+
+ensureHappyDom();
+
+function installContentUtilsStub() {
+  const previous = (window as typeof window & { ChatGPTToolkitContentUtils?: unknown })
+    .ChatGPTToolkitContentUtils;
+
+  (window as typeof window & { ChatGPTToolkitContentUtils?: unknown }).ChatGPTToolkitContentUtils = {
+    parseToolkitHash: () => ({
+      prompt: null,
+      autoSubmit: false,
+      pasteImage: false,
+      tool: '',
+    }),
+  };
+
+  return () => {
+    (window as typeof window & { ChatGPTToolkitContentUtils?: unknown }).ChatGPTToolkitContentUtils = previous;
+  };
+}
+
+describe('content context prompt composition', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('buildPrefixedText keeps existing text after the prefix', () => {
+    expect(buildPrefixedText('前綴', '原文')).toBe('前綴\n原文');
+    expect(buildPrefixedText('前綴\n', '原文')).toBe('前綴\n原文');
+    expect(buildPrefixedText('', '原文')).toBe('原文');
+  });
+
+  test('resolvePromptText uses {{args}} when present and otherwise appends clipboard text', () => {
+    expect(resolvePromptText('請評論：\n\n', '  剪貼簿內容  ')).toBe('請評論：\n\n剪貼簿內容');
+    expect(resolvePromptText('前綴 {{args}} 後綴', '  剪貼簿內容  ')).toBe('前綴 剪貼簿內容 後綴');
+  });
+
+  test('content helpers preserve the existing content when requested', () => {
+    const restoreUtils = installContentUtilsStub();
+
+    try {
+      const ctx = createContentContext();
+      expect(ctx).not.toBeNull();
+      if (!ctx) return;
+
+      const editor = document.createElement('div');
+      editor.setAttribute('contenteditable', 'true');
+      editor.innerHTML = '<p>原文</p>';
+
+      const textarea = document.createElement('textarea');
+      textarea.value = '原文';
+
+      ctx.fillContentEditableWithParagraphs(editor, '前綴', true);
+      ctx.fillTextareaAndDispatchInput(textarea, '前綴', true);
+
+      expect(editor.children.length).toBe(2);
+      expect(editor.children[0].textContent).toBe('前綴');
+      expect(editor.children[1].textContent).toBe('原文');
+      expect(textarea.value).toBe('前綴\n原文');
+
+      ctx.fillContentEditableWithParagraphs(editor, '前綴', true);
+      ctx.fillTextareaAndDispatchInput(textarea, '前綴', true);
+
+      expect(editor.children.length).toBe(2);
+      expect(editor.children[0].textContent).toBe('前綴');
+      expect(editor.children[1].textContent).toBe('原文');
+      expect(textarea.value).toBe('前綴\n原文');
+    } finally {
+      restoreUtils();
+    }
+  });
+});

--- a/tests/content-context.test.ts
+++ b/tests/content-context.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test } from 'bun:test';
 import {
   buildPrefixedText,
   createContentContext,
+  normalizeComparableText,
   resolvePromptText,
 } from '../src/content/context';
 import { ensureHappyDom } from './utils/happyDom';
@@ -42,6 +43,10 @@ describe('content context prompt composition', () => {
     expect(resolvePromptText('前綴 {{args}} 後綴', '  剪貼簿內容  ')).toBe('前綴 剪貼簿內容 後綴');
   });
 
+  test('normalizeComparableText normalizes whitespace consistently', () => {
+    expect(normalizeComparableText(' \u00A0foo\n\tbar\u200B ')).toBe('foo bar');
+  });
+
   test('content helpers preserve the existing content when requested', () => {
     const restoreUtils = installContentUtilsStub();
 
@@ -72,6 +77,59 @@ describe('content context prompt composition', () => {
       expect(editor.children[0].textContent).toBe('前綴');
       expect(editor.children[1].textContent).toBe('原文');
       expect(textarea.value).toBe('前綴\n原文');
+    } finally {
+      restoreUtils();
+    }
+  });
+
+  test('content helpers do not treat partial word matches as an existing prefix', () => {
+    const restoreUtils = installContentUtilsStub();
+
+    try {
+      const ctx = createContentContext();
+      expect(ctx).not.toBeNull();
+      if (!ctx) return;
+
+      const editor = document.createElement('div');
+      editor.setAttribute('contenteditable', 'true');
+      editor.innerHTML = '<p>hello</p>';
+
+      const textarea = document.createElement('textarea');
+      textarea.value = 'hello';
+
+      ctx.fillContentEditableWithParagraphs(editor, 'he', true);
+      ctx.fillTextareaAndDispatchInput(textarea, 'he', true);
+
+      expect(editor.children.length).toBe(2);
+      expect(editor.children[0].textContent).toBe('he');
+      expect(editor.children[1].textContent).toBe('hello');
+      expect(textarea.value).toBe('he\nhello');
+    } finally {
+      restoreUtils();
+    }
+  });
+
+  test('content helpers prefer innerText for connected contenteditable elements', () => {
+    const restoreUtils = installContentUtilsStub();
+
+    try {
+      const ctx = createContentContext();
+      expect(ctx).not.toBeNull();
+      if (!ctx) return;
+
+      const editor = document.createElement('div');
+      editor.setAttribute('contenteditable', 'true');
+      editor.innerHTML = 'alpha<br>';
+      Object.defineProperty(editor, 'innerText', {
+        configurable: true,
+        get: () => 'alpha',
+      });
+      document.body.appendChild(editor);
+
+      ctx.fillContentEditableWithParagraphs(editor, 'alpha', true);
+
+      expect(editor.children.length).toBe(1);
+      expect(editor.children[0].textContent).toBe('alpha');
     } finally {
       restoreUtils();
     }

--- a/tests/gemini-initial-buttons.test.ts
+++ b/tests/gemini-initial-buttons.test.ts
@@ -250,7 +250,7 @@ describe('gemini initial buttons', () => {
     loadDom(`
       <input-container>
         <rich-textarea>
-          <div class="ql-editor" contenteditable="true" role="textbox"></div>
+          <div class="ql-editor" contenteditable="true" role="textbox"><p>既有內容</p></div>
         </rich-textarea>
       </input-container>
     `);
@@ -282,7 +282,9 @@ describe('gemini initial buttons', () => {
 
       const editor = document.querySelector<HTMLElement>('input-container rich-textarea .ql-editor');
       expect(editor).not.toBeNull();
-      expect(editor?.textContent).toBe('你好');
+      expect(editor?.children.length).toBe(2);
+      expect(editor?.children[0].textContent).toBe('你好');
+      expect(editor?.children[1].textContent).toBe('既有內容');
       expect(clearHashCalls).toBe(1);
     } finally {
       restoreChrome();

--- a/tests/gemini-initial-buttons.test.ts
+++ b/tests/gemini-initial-buttons.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { initGemini } from '../src/content/sites/gemini';
 import type { ContentContext } from '../src/content/context';
+import { buildPrefixedText, hasPrefixText } from '../src/content/context';
 import { ensureHappyDom } from './utils/happyDom';
 
 ensureHappyDom();
@@ -55,9 +56,15 @@ function createPromptFillContext(options?: {
     clearHash: () => {
       options?.onClearHash?.();
     },
-    fillContentEditableWithParagraphs: (target, text) => {
+    fillContentEditableWithParagraphs: (target, text, preserveExistingText = false) => {
       if (!target) return;
-      const lines = (text || '').split('\n');
+      const existingText = target.isConnected ? target.innerText : target.textContent || '';
+      const nextText = preserveExistingText
+        ? hasPrefixText(existingText, text)
+          ? existingText
+          : buildPrefixedText(text, existingText)
+        : text;
+      const lines = (nextText || '').split('\n');
       target.innerHTML = '';
       lines.forEach((line) => {
         const paragraph = document.createElement('p');
@@ -487,6 +494,13 @@ describe('gemini initial buttons', () => {
     const restoreChrome = installChromeStub();
 
     try {
+      const editor = document.querySelector<HTMLElement>('input-container rich-textarea .ql-editor');
+      expect(editor).not.toBeNull();
+      Object.defineProperty(editor!, 'innerText', {
+        configurable: true,
+        get: () => '既有內容',
+      });
+
       initGemini(
         createPromptFillContext({
           prompt: '你好',
@@ -498,8 +512,6 @@ describe('gemini initial buttons', () => {
 
       await flushAsyncWork();
 
-      const editor = document.querySelector<HTMLElement>('input-container rich-textarea .ql-editor');
-      expect(editor).not.toBeNull();
       expect(editor?.children.length).toBe(2);
       expect(editor?.children[0].textContent).toBe('你好');
       expect(editor?.children[1].textContent).toBe('既有內容');


### PR DESCRIPTION
目前這個外掛的按鈕行為，是把按鈕對應的 prompt 直接寫入輸入框，所以原本已經輸入的文字會被覆蓋。現在改成「保留原文，並把新文字插到開頭」。

避免按一下按鈕就把原本辛苦輸入的 prompt 移除。